### PR TITLE
Add option to print the callsite of a todo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - "1.9.3"
-  - "2.0.0"
+  - "2.1.10"
+  - "2.2.6"
+  - "2.3.3"
+  - "2.4.0"
   - jruby-19mode
 script: bundle exec rspec spec

--- a/lib/activetodo.rb
+++ b/lib/activetodo.rb
@@ -21,6 +21,14 @@ module ActiveTodo
       def ignore_production=(condition)
         @@ignore_production = condition
       end
+
+      def show_callsite?
+        @@show_callsite ||= false
+      end
+
+      def show_callsite=(condition)
+        @@show_callsite = condition
+      end
     end
   end
 
@@ -47,9 +55,11 @@ module ActiveTodo
 
     def TODO(what, options = {})
       deadline = DateTime.parse(options[:deadline]) if options[:deadline]
+      callsite = caller.first if Configuration.show_callsite?
 
       if deadline && DateTime.now >= deadline
         message = "Deadline reached for \"#{what}\" (#{options[:deadline]})"
+        message += " in #{callsite}" if callsite
 
         if Configuration.warn_only?(options)
           PrivateMethods.log_message(message, options)

--- a/spec/activetodo_spec.rb
+++ b/spec/activetodo_spec.rb
@@ -98,5 +98,17 @@ describe ActiveTodo::KernelMethods do
         end
       end
     end
+
+    context 'when call site logging enabled' do
+      subject { TODO 'remove this', deadline: (Time.now - 3600).to_s }
+
+      before do
+        ActiveTodo.configure { |c| c.show_callsite = true }
+        filename_pattern = /#{Regexp.escape(Pathname(__FILE__).basename.to_s)}/
+        ActiveTodo::PrivateMethods.should_receive(:log_message).with(filename_pattern, anything)
+      end
+
+      specify { expect { subject }.not_to raise_error }
+    end
   end
 end


### PR DESCRIPTION
Surprise! 😄 

I launched my amazing Rails app and saw a bunch of:
```
Deadline reached for "remove" (2017-02-14)
Deadline reached for "remove" (2017-02-14)
Deadline reached for "remove" (2017-02-14)
...
```

I was not amused, it's pretty hard to find where these are coming from.

With this change a file and line number will be appended to the messages:
```
Deadline reached for "remove" (2017-02-14) in /Users/superman/my/amazing/project/app/controllers/api/api9000_controller.rb:882
Deadline reached for "remove" (2017-02-14) in /Users/superman/my/amazing/project/app/controllers/api/api9000_controller.rb:3123
Deadline reached for "remove" (2017-02-14) in /Users/superman/my/amazing/project/app/controllers/api/api9000_controller.rb:6234
```

Super amazing, right?